### PR TITLE
optimizations for memset on x86_64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-10-01  Jakob Löw <jakob@m4gnus.de>
+
+	* jit/jit-gen-x86-64.h: add the movlhps and movhlps instructions
+	* jit/jit-rules-x86-64.ins
+	* jit/jit-rules-x86-64.c: Inline memset instructions when value and size
+	are known during compilation.
+
 2017-08-28  Aleksey Demakov  <ademakov@gmail.com>
 
 	* jit/jit-value.c (jit_value_create_long_constant): on 64-bit

--- a/jit/jit-gen-x86-64.h
+++ b/jit/jit-gen-x86-64.h
@@ -932,7 +932,7 @@ typedef union
 		*(inst)++ = (unsigned char)(opc1); \
 		x86_64_membase_emit((inst), (r), (basereg), (disp)); \
 	} while(0)
-	
+
 #define x86_64_alu1_memindex(inst, opc1, r, basereg, disp, indexreg, shift) \
 	do { \
 		x86_64_rex_emit((inst), 0, 0, (indexreg), (basereg)); \
@@ -983,7 +983,7 @@ typedef union
 		x86_64_opcode1_emit((inst), (opc1), (size)); \
 		x86_64_membase_emit((inst), (r), (basereg), (disp)); \
 	} while(0)
-	
+
 #define x86_64_alu1_memindex_size(inst, opc1, r, basereg, disp, indexreg, shift, size) \
 	do { \
 		if((size) == 2) \
@@ -1038,7 +1038,7 @@ typedef union
 		*(inst)++ = (unsigned char)(opc1); \
 		x86_64_membase_emit((inst), (dreg), (basereg), (disp)); \
 	} while(0)
-	
+
 #define x86_64_alu1_reg_memindex_size(inst, opc1, dreg, basereg, disp, indexreg, shift, size) \
 	do { \
 		if((size) == 2) \
@@ -1097,7 +1097,7 @@ typedef union
 		*(inst)++ = (unsigned char)(opc2); \
 		x86_64_membase_emit((inst), (dreg), (basereg), (disp)); \
 	} while(0)
-	
+
 #define x86_64_alu2_reg_memindex_size(inst, opc1, opc2, dreg, basereg, disp, indexreg, shift, size) \
 	do { \
 		if((size) == 2) \
@@ -1850,7 +1850,7 @@ typedef union
 	} while(0)
 
 /*
- * neg 
+ * neg
  */
 #define x86_64_neg_reg_size(inst, reg, size) \
 	do { \
@@ -3342,7 +3342,7 @@ typedef union
 	do { \
 		x86_64_alu1_membase((inst), 0xff, 2, (basereg), (disp)); \
 	} while(0)
-	
+
 #define x86_64_call_memindex(inst, basereg, disp, indexreg, shift) \
 	do { \
 		x86_64_alu1_memindex((inst), 0xff, 2, (basereg), (disp), (indexreg), (shift)); \
@@ -3389,7 +3389,7 @@ typedef union
 	do { \
 		x86_64_alu1_membase((inst), 0xff, 4, (basereg), (disp)); \
 	} while(0)
-	
+
 #define x86_64_jmp_memindex(inst, basereg, disp, indexreg, shift) \
 	do { \
 		x86_64_alu1_memindex((inst), 0xff, 4, (basereg), (disp), (indexreg), (shift)); \
@@ -3916,6 +3916,19 @@ typedef union
 #define x86_64_movups_reg_memindex(inst, dreg, basereg, disp, indexreg, shift) \
 	do { \
 		x86_64_xmm2_reg_memindex((inst), 0x0f, 0x10, (dreg), (basereg), (disp), (indexreg), (shift)); \
+	} while(0)
+
+/*
+ * movlhps: Move lower 64bit of sreg to higher 64bit of dreg
+ * movhlps: Move higher 64bit of sreg to lower 64bit of dreg
+ */
+#define x86_64_movlhps(inst, dreg, sreg) \
+	do { \
+		x86_64_xmm2_reg_reg((inst), 0x0f, 0x16, (dreg), (sreg)); \
+	} while(0)
+#define x86_64_movhlps(inst, dreg, sreg) \
+	do { \
+		x86_64_xmm2_reg_reg((inst), 0x0f, 0x12, (dreg), (sreg)); \
 	} while(0)
 
 /*

--- a/jit/jit-rules-x86-64.c
+++ b/jit/jit-rules-x86-64.c
@@ -2748,17 +2748,35 @@ small_block_set(jit_gencode_t gen, unsigned char *inst,
 {
 	jit_nint offset = 0;
 
-	for(int i = 0; i < 8; i++)
+	if(val == 0)
 	{
-		val = (val << 8) | (val & 0xff);
+		if(!use_sse || size % 16 != 0)
+		{
+			x86_64_clear_reg(inst, scratch_reg);
+		}
 	}
-	x86_64_mov_reg_imm_size(inst, scratch_reg, val, 8);
+	else
+	{
+		for(int i = 0; i < 8; i++)
+		{
+			val = (val << 8) | (val & 0xff);
+		}
+		x86_64_mov_reg_imm_size(inst, scratch_reg, val, 8);
+	}
 
 	/* Set all 16 byte blocks */
 	if(use_sse)
 	{
-		x86_64_movq_xreg_reg(inst, scratch_xreg, scratch_reg);
-		x86_64_movlhps(inst, scratch_xreg, scratch_xreg);
+		if(val == 0)
+		{
+			x86_64_clear_xreg(inst, scratch_xreg);
+		}
+		else
+		{
+			x86_64_movq_xreg_reg(inst, scratch_xreg, scratch_reg);
+			x86_64_movlhps(inst, scratch_xreg, scratch_xreg);
+		}
+
 		while(size >= 16)
 		{
 			if(is_aligned)

--- a/jit/jit-rules-x86-64.c
+++ b/jit/jit-rules-x86-64.c
@@ -140,6 +140,11 @@ do { \
 #define _JIT_MAX_MEMCPY_INLINE	0x40
 
 /*
+ * The maximum block size set inline
+ */
+#define _JIT_MAX_MEMSET_INLINE 0x80
+
+/*
  * va_list type as specified in x86_64 sysv abi version 0.99
  * Figure 3.34
  */
@@ -2610,8 +2615,9 @@ small_block_copy(jit_gencode_t gen, unsigned char *inst,
 				 int sreg, jit_nint soffset, jit_int size,
 				 int scratch_reg, int scratch_xreg, int is_aligned)
 {
-	int offset = 0;
+	jit_nint offset = 0;
 
+	/* Copy all 16 byte blocks of the struct */
 	while(size >= 16)
 	{
 		if(is_aligned)
@@ -2631,42 +2637,17 @@ small_block_copy(jit_gencode_t gen, unsigned char *inst,
 		size -= 16;
 		offset += 16;
 	}
+
 	/* Now copy the rest of the struct */
-	if(size >= 8)
+	for(int i = 8; i > 0; i /= 2)
 	{
-		x86_64_mov_reg_membase_size(inst, scratch_reg,
-									sreg, soffset + offset, 8);
-		x86_64_mov_membase_reg_size(inst, dreg, doffset + offset,
-									scratch_reg, 8);
-		size -= 8;
-		offset += 8;
-	}
-	if(size >= 4)
-	{
-		x86_64_mov_reg_membase_size(inst, scratch_reg,
-									sreg, soffset + offset, 4);
-		x86_64_mov_membase_reg_size(inst, dreg, doffset + offset,
-									scratch_reg, 4);
-		size -= 4;
-		offset += 4;
-	}
-	if(size >= 2)
-	{
-		x86_64_mov_reg_membase_size(inst, scratch_reg,
-									sreg, soffset + offset, 2);
-		x86_64_mov_membase_reg_size(inst, dreg, doffset + offset,
-									scratch_reg, 2);
-		size -= 2;
-		offset += 2;
-	}
-	if(size >= 1)
-	{
-		x86_64_mov_reg_membase_size(inst, scratch_reg,
-									sreg, soffset + offset, 1);
-		x86_64_mov_membase_reg_size(inst, dreg, doffset + offset,
-									scratch_reg, 1);
-		size -= 1;
-		offset += 1;
+		if(size >= i)
+		{
+			x86_64_mov_membase_reg_size(inst, dreg, doffset + offset,
+										scratch_reg, i);
+			size -= i;
+			offset += i;
+		}
 	}
 	return inst;
 }
@@ -2746,6 +2727,66 @@ memory_copy(jit_gencode_t gen, unsigned char *inst,
 		x86_64_add_reg_imm_size(inst, X86_64_RDI, doffset, 8);
 	}
 	inst = x86_64_call_code(inst, (jit_nint)jit_memcpy);
+	return inst;
+}
+
+/*
+ * Set a small block. This code will be inlined.
+ * Set is_aligned to 0 if you don't know if the source and target locations
+ * are aligned on a 16byte boundary and != 0 if you know that both blocks are
+ * aligned.
+ * Set use_sse to 0 if you don't want to use SSE. Setting this to non-zero
+ * will make this function ignore src_xreg
+ * We assume that offset + size is in the range -2GB ... +2GB.
+ */
+static unsigned char *
+small_block_set(jit_gencode_t gen, unsigned char *inst,
+				int dreg, jit_nint doffset,
+				jit_nint val, jit_nint size,
+				int scratch_reg, int scratch_xreg,
+				int is_aligned, int use_sse)
+{
+	jit_nint offset = 0;
+
+	for(int i = 0; i < 8; i++)
+	{
+		val = (val << 8) | (val & 0xff);
+	}
+	x86_64_mov_reg_imm_size(inst, scratch_reg, val, 8);
+
+	/* Set all 16 byte blocks */
+	if(use_sse)
+	{
+		x86_64_movq_xreg_reg(inst, scratch_xreg, scratch_reg);
+		x86_64_movlhps(inst, scratch_xreg, scratch_xreg);
+		while(size >= 16)
+		{
+			if(is_aligned)
+			{
+				x86_64_movaps_membase_reg(inst, dreg, doffset + offset,
+										  scratch_xreg);
+			}
+			else
+			{
+				x86_64_movups_membase_reg(inst, dreg, doffset + offset,
+										  scratch_xreg);
+			}
+			size -= 16;
+			offset += 16;
+		}
+	}
+
+	/* Now set the rest */
+	for(int i = 8; i > 0; i /= 2)
+	{
+		while(size >= i)
+		{
+			x86_64_mov_membase_reg_size(inst, dreg, doffset + offset,
+										scratch_reg, i);
+			size -= i;
+			offset += i;
+		}
+	}
 	return inst;
 }
 

--- a/jit/jit-rules-x86-64.c
+++ b/jit/jit-rules-x86-64.c
@@ -2742,13 +2742,13 @@ memory_copy(jit_gencode_t gen, unsigned char *inst,
 static unsigned char *
 small_block_set(jit_gencode_t gen, unsigned char *inst,
 				int dreg, jit_nint doffset,
-				jit_nint val, jit_nint size,
+				jit_nuint val, jit_nint size,
 				int scratch_reg, int scratch_xreg,
 				int is_aligned, int use_sse)
 {
 	jit_nint offset = 0;
 
-	if(val == 0)
+	if(val & 0xff == 0)
 	{
 		if(!use_sse || size % 16 != 0)
 		{

--- a/jit/jit-rules-x86-64.ins
+++ b/jit/jit-rules-x86-64.ins
@@ -19,7 +19,7 @@
  * License along with the libjit library.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
+
 %regclass reg x86_64_reg
 %regclass creg x86_64_creg
 %regclass dreg x86_64_dreg
@@ -27,7 +27,7 @@
 %regclass sreg x86_64_sreg
 %regclass freg x86_64_freg
 %regclass xreg x86_64_xreg
- 
+
 /*
  * Conversion opcodes.
  */
@@ -81,7 +81,7 @@ JIT_OP_LOW_WORD:
 			x86_64_mov_reg_reg_size(inst, $1, $2, 4);
 		}
 	}
-	
+
 JIT_OP_EXPAND_INT:
 	[=reg, reg] -> {
 		x86_64_movsx32_reg_reg_size(inst, $1, $2, 8);
@@ -758,11 +758,11 @@ JIT_OP_LOAD_RELATIVE_FLOAT64:
 			x86_64_movsd_reg_regp(inst, $1, $2);
 		}
 		else
-		{		
+		{
 			x86_64_movsd_reg_membase(inst, $1, $2, $3);
 		}
 	}
-	
+
 JIT_OP_LOAD_RELATIVE_NFLOAT:
 	[=freg, reg, imm, if("sizeof(jit_nfloat) != sizeof(jit_float64)")] -> {
 		x86_64_fld_membase_size(inst, $2, $3, 10);
@@ -887,7 +887,7 @@ JIT_OP_STORE_RELATIVE_FLOAT32: ternary
 			x86_64_movss_regp_reg(inst, $1, $2);
 		}
 		else
-		{	
+		{
 			x86_64_movss_membase_reg(inst, $1, $3, $2);
 		}
 	}
@@ -903,7 +903,7 @@ JIT_OP_STORE_RELATIVE_FLOAT64: ternary
 			x86_64_movsd_regp_reg(inst, $1, $2);
 		}
 		else
-		{	
+		{
 			x86_64_movsd_membase_reg(inst, $1, $3, $2);
 		}
 	}
@@ -3271,6 +3271,15 @@ JIT_OP_MEMCPY: ternary
 	}
 
 JIT_OP_MEMSET: ternary
+	[any, any, imm, if("$3 <= 0")] -> { }
+	[reg, imm, imm, scratch reg,
+		if("$3 <= _JIT_MAX_MEMSET_INLINE && $3 < 32")] -> {
+		inst = small_block_set(gen, inst, $1, 0, $2, $3, $4, 0, 0, 0);
+	}
+	[reg, imm, imm, scratch reg, scratch xreg,
+		if("$3 <= _JIT_MAX_MEMSET_INLINE")] -> {
+		inst = small_block_set(gen, inst, $1, 0, $2, $3, $4, $5, 0, 1);
+	}
 	[reg("rdi"), reg("rsi"), reg("rdx"), clobber(creg), clobber(xreg)] -> {
 		inst = x86_64_call_code(inst, (jit_nint)jit_memset);
 	}

--- a/jit/jit-rules-x86-64.ins
+++ b/jit/jit-rules-x86-64.ins
@@ -3272,6 +3272,10 @@ JIT_OP_MEMCPY: ternary
 
 JIT_OP_MEMSET: ternary
 	[any, any, imm, if("$3 <= 0")] -> { }
+	[reg, imm, imm, scratch xreg,
+		if("$2 == 0 && $3 <= _JIT_MAX_MEMSET_INLINE && $3 % 16 == 0")] -> {
+		inst = small_block_set(gen, inst, $1, 0, $2, $3, 0, $4, 0, 1);
+	}
 	[reg, imm, imm, scratch reg,
 		if("$3 <= _JIT_MAX_MEMSET_INLINE && $3 < 32")] -> {
 		inst = small_block_set(gen, inst, $1, 0, $2, $3, $4, 0, 0, 0);


### PR DESCRIPTION
Currently when calling `jit_insn_memset` on x86_64 all libjit does is generate a call to `memset`. With this commit memsets up to 0x80 bytes get inlined using SSE where applicable.

For example the following code:
```C
char buff[64];
jit_value_t array = jit_value_create_nint_constant(func,
	jit_type_void_ptr, (uintptr_t)buff);
jit_value_t value = jit_value_create_nint_constant(func, jit_type_sbyte, 0);
jit_value_t size = jit_value_create_nint_constant(func, jit_type_nuint, 64);

jit_insn_memset(func, array, value, size);
```

used to produce
```S
    7fdaf193a150:	48 bf c0 5b 42 74 fc 	movabs $0x7ffc74425bc0,%rdi
    7fdaf193a157:	7f 00 00 
    7fdaf193a15a:	33 f6                	xor    %esi,%esi
    7fdaf193a15c:	ba 40 00 00 00       	mov    $0x40,%edx
    7fdaf193a161:	b8 08 00 00 00       	mov    $0x8,%eax
    7fdaf193a166:	49 bb b0 50 08 b6 57 	movabs $0x5557b60850b0,%r11
    7fdaf193a16d:	55 00 00 
    7fdaf193a170:	41 ff d3             	callq  *%r11
```

and with this commit it turns to
```S
    7fa5da950150:	48 b8 70 d2 95 80 fe 	movabs $0x7ffe8095d270,%rax
    7fa5da950157:	7f 00 00
    7fa5da95015a:	0f 57 c0             	xorps  %xmm0,%xmm0
    7fa5da95015d:	0f 11 00             	movups %xmm0,(%rax)
    7fa5da950160:	0f 11 40 10          	movups %xmm0,0x10(%rax)
    7fa5da950164:	0f 11 40 20          	movups %xmm0,0x20(%rax)
    7fa5da950168:	0f 11 40 30          	movups %xmm0,0x30(%rax)
```

Of course using memset with value 0 and a 16 byte aligned size is optimal.
Using value 42 and size 37 it turns into the following
```S
    7f400bcef150:	48 b8 a0 57 2d c5 fd 	movabs $0x7ffdc52d57a0,%rax
    7f400bcef157:	7f 00 00 
    7f400bcef15a:	48 b9 2a 2a 2a 2a 2a 	movabs $0x2a2a2a2a2a2a2a2a,%rcx
    7f400bcef161:	2a 2a 2a 
    7f400bcef164:	66 48 0f 6e c1       	movq   %rcx,%xmm0
    7f400bcef169:	0f 16 c0             	movlhps %xmm0,%xmm0
    7f400bcef16c:	0f 11 00             	movups %xmm0,(%rax)
    7f400bcef16f:	0f 11 40 10          	movups %xmm0,0x10(%rax)
    7f400bcef173:	89 48 20             	mov    %ecx,0x20(%rax)
    7f400bcef176:	88 48 24             	mov    %cl,0x24(%rax)
```