### PR TITLE
fix undefined behaviour in memset on x86-64 with a value of 0

### DIFF
--- a/jit/jit-rules-x86-64.c
+++ b/jit/jit-rules-x86-64.c
@@ -2748,7 +2748,7 @@ small_block_set(jit_gencode_t gen, unsigned char *inst,
 {
 	jit_nint offset = 0;
 
-	if(val & 0xff == 0)
+	if((val & 0xff) == 0)
 	{
 		if(!use_sse || size % 16 != 0)
 		{
@@ -2767,7 +2767,7 @@ small_block_set(jit_gencode_t gen, unsigned char *inst,
 	/* Set all 16 byte blocks */
 	if(use_sse)
 	{
-		if(val == 0)
+		if((val & 0xff) == 0)
 		{
 			x86_64_clear_xreg(inst, scratch_xreg);
 		}


### PR DESCRIPTION
the error is in the expression `val & 0xff == 0` because in C `==` binds stronger
than `&` resulting in `val & (0xff == 0)` i.e. `val & 0` i.e. `0`. This error was
particularly bad when memset was called with a 16 byte aligned size and value 0
as it then zeroed register 0 (rax) which might be used for something else.

I actually added the `& 0xff` part in the tidy up commit (2904804a1fb8e6986aa4f32521bcc6849d1a658c) as it catches the case when someone passes a value > 255 as memset is ment to ignore everything but the lowest byte of a value.

I am sorry this made its way into upstream.