### PR TITLE
Don't double align the size of alloca instructions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-10-09  Jakob Löw  <jakob@m4gnus.de>
+
+	* jit/jit-rules-arm.ins
+	* jit/jit-rules-x86.ins
+	* jit/jit-rules-x86-64.ins: don't align the size of an alloca instruction as
+	the frontend already handles that.
+
 2017-10-07  Aleksey Demakov  <ademakov@gmail.com>
 
 	* jit/jit-rules-x86-64.c (small_block_set): fix a bug.

--- a/jit/jit-rules-arm.ins
+++ b/jit/jit-rules-arm.ins
@@ -1875,10 +1875,6 @@ JIT_OP_STORE_ELEMENT_FLOAT64: ternary
 */
 JIT_OP_ALLOCA:
 [reg] -> {
-	//The ARM stack must always be 4-byte aligned and must be 8-byte aligned at a public interface.
-	//Since we don't know when this function will be called, let's align to 8 bytes.
-	arm_alu_reg_imm(inst, ARM_ADD, $1, $1, 7);
-	arm_alu_reg_imm(inst, ARM_AND, $1, $1, ~7);
 	arm_alu_reg_reg(inst, ARM_SUB, ARM_SP, ARM_SP, $1);
 	arm_mov_reg_reg(inst, $1, ARM_SP);
 	gen->stack_changed = 1;

--- a/jit/jit-rules-x86-64.ins
+++ b/jit/jit-rules-x86-64.ins
@@ -3290,8 +3290,6 @@ JIT_OP_MEMSET: ternary
 
 JIT_OP_ALLOCA:
 	[reg] -> {
-		x86_64_add_reg_imm_size(inst, $1, 15, 8);
-		x86_64_and_reg_imm_size(inst, $1, ~15, 8);
 		x86_64_sub_reg_reg_size(inst, X86_64_RSP, $1, 8);
 		x86_64_mov_reg_reg_size(inst, $1, X86_64_RSP, 8);
 		inst = fixup_alloca(gen, inst, $1);

--- a/jit/jit-rules-x86.ins
+++ b/jit/jit-rules-x86.ins
@@ -2653,8 +2653,6 @@ JIT_OP_MEMSET: ternary
 
 JIT_OP_ALLOCA:
 	[reg] -> {
-		x86_alu_reg_imm(inst, X86_ADD, $1, 15);
-		x86_alu_reg_imm(inst, X86_AND, $1, ~15);
 		x86_alu_reg_reg(inst, X86_SUB, X86_ESP, $1);
 		x86_mov_reg_reg(inst, $1, X86_ESP, 4);
 		gen->stack_changed = 1;


### PR DESCRIPTION
The front end already aligns the size of alloca instructions to `JIT_BEST_ALIGNMENT` (see [jit-insn.c:7703](https://github.com/ademakov/libjit/blob/master/jit/jit-insn.c#L7703-L7716)).
Without this commit all of the backend implementations do it a second time. Another approach would be to remove the alignment from the frontend.

alloca before this commit (on x86-64):
```S
    7f6724ac1178:	48 05 0f 00 00 00    	add    $0xf,%rax
    7f6724ac117e:	48 25 f0 ff ff ff    	and    $0xfffffffffffffff0,%rax
    7f6724ac1184:	48 05 0f 00 00 00    	add    $0xf,%rax
    7f6724ac118a:	48 25 f0 ff ff ff    	and    $0xfffffffffffffff0,%rax
    7f6724ac1190:	48 2b e0             	sub    %rax,%rsp
    7f6724ac1193:	48 8b c4             	mov    %rsp,%rax
```

alloca after this commit (on x86-64):
```S
    7f900d5d9178:	48 05 0f 00 00 00    	add    $0xf,%rax
    7f900d5d917e:	48 25 f0 ff ff ff    	and    $0xfffffffffffffff0,%rax
    7f900d5d9184:	48 2b e0             	sub    %rax,%rsp
    7f900d5d9187:	48 8b c4             	mov    %rsp,%rax
```