### PR TITLE
Prefer the 8 bit sign extended alu instruction encoding in x86-64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-10-09  Jakob Löw  <jakob@m4gnus.de>
+
+	* jit/jit-gen-x86.h
+	* jit/jit-gen-x86-64.h: Always use the 8 bit sign extended alu instruction
+	encoding when possible, reducing code size by two bytes when the target
+	register is rax or eax
+
 2017-10-21  Aleksey Demakov  <ademakov@gmail.com>
 
 	* jit/jit-insn.c (apply_compare): fix (perhaps) constant comparison

--- a/jit/jit-gen-x86.h
+++ b/jit/jit-gen-x86.h
@@ -260,8 +260,8 @@ typedef union {
 	} while (0)
 #define x86_imm_emit16(inst,imm)     do { *(short*)(inst) = (imm); (inst) += 2; } while (0)
 #define x86_imm_emit8(inst,imm)      do { *(inst) = (unsigned char)((imm) & 0xff); ++(inst); } while (0)
-#define x86_is_imm8(imm)             (((int)(imm) >= -128 && (int)(imm) <= 127))
-#define x86_is_imm16(imm)            (((int)(imm) >= -(1<<16) && (int)(imm) <= ((1<<16)-1)))
+#define x86_is_imm8(imm)             (((jit_nint)(imm) >= -128 && (jit_nint)(imm) <= 127))
+#define x86_is_imm16(imm)            (((jit_nint)(imm) >= -(1<<16) && (jit_nint)(imm) <= ((1<<16)-1)))
 
 #define x86_reg_emit(inst,r,regno)   do { x86_address_byte ((inst), 3, (r), (regno)); } while (0)
 #define x86_reg8_emit(inst,r,regno,is_rh,is_rnoh)   do {x86_address_byte ((inst), 3, (is_rh)?((r)|4):(r), (is_rnoh)?((regno)|4):(regno));} while (0)


### PR DESCRIPTION
ALU instructions like `add imm %rax` with sign extended immediate can be encoded in multiple ways.

- the `add imm32 r64` way
- the `add imm32 %rax` way
- or the `add imm8 r64` way.

Previousely libjit preferred the second way even if the immediate was between -128 and 127. The third way makes the operation, even when not using the rax specific opcode, two bytes shorter.

Here is a small example taken from #7. Notice how the same instructions on the right are represented by two bytes less in the middle.

Before:
```S
    7f900d5d9178:	48 05 0f 00 00 00    	add    $0xf,%rax
    7f900d5d917e:	48 25 f0 ff ff ff    	and    $0xfffffffffffffff0,%rax
    7f900d5d9184:	48 2b e0             	sub    %rax,%rsp
    7f900d5d9187:	48 8b c4             	mov    %rsp,%rax
```
After:
```S
    7f9663b13155:	48 83 c0 0f          	add    $0xf,%rax
    7f9663b13159:	48 83 e0 f0          	and    $0xfffffffffffffff0,%rax
    7f9663b1315d:	48 2b e0             	sub    %rax,%rsp
    7f9663b13160:	48 8b c4             	mov    %rsp,%rax
```

The file diff looks kind of messed up, but I actually just moved the lower is_imm8 if above the rax if.