### PR TITLE
Use const char* for yyerror, to allow building with -Werror=format-security

### DIFF
--- a/jit/jit-apply.c
+++ b/jit/jit-apply.c
@@ -239,8 +239,6 @@ static void
 jit_apply_builder_get_return(jit_apply_builder *builder, void *rv,
 			     jit_type_t type, jit_apply_return *result)
 {
-	unsigned int size;
-
 	switch(type->kind)
 	{
 	case JIT_TYPE_SBYTE:

--- a/tools/gen-ops-parser.y
+++ b/tools/gen-ops-parser.y
@@ -210,7 +210,7 @@ static struct genops_opcode_list *opcode_header = 0;
  * Report error message.
  */
 static void
-genops_error_message(char *filename, long linenum, char *msg)
+genops_error_message(const char *filename, long linenum, const char *msg)
 {
 	fprintf(stderr, "%s(%ld): %s\n", filename, linenum, msg);
 }
@@ -219,7 +219,7 @@ genops_error_message(char *filename, long linenum, char *msg)
  * Report error messages from the parser.
  */
 static void
-yyerror(char *msg)
+yyerror(const char *msg)
 {
 	genops_error_message(genops_filename, genops_linenum, msg);
 }
@@ -296,7 +296,7 @@ static int
 genops_output_flag(const char *flag, int needs_or)
 {
 	if(needs_or) printf(" | ");
-	printf(flag);
+	printf("%s", flag);
 	return 1;
 }
 

--- a/tools/gen-rules-parser.y
+++ b/tools/gen-rules-parser.y
@@ -54,7 +54,7 @@ extern long gensel_linenum;
  * Report error message.
  */
 static void
-gensel_error_message(char *filename, long linenum, char *msg)
+gensel_error_message(const char *filename, long linenum, const char *msg)
 {
 	fprintf(stderr, "%s(%ld): %s\n", filename, linenum, msg);
 }
@@ -63,7 +63,7 @@ gensel_error_message(char *filename, long linenum, char *msg)
  * Report error message and exit.
  */
 static void
-gensel_error(char *filename, long linenum, char *msg)
+gensel_error(const char *filename, long linenum, const char *msg)
 {
 	gensel_error_message(filename, linenum, msg);
 	exit(1);
@@ -859,13 +859,13 @@ gensel_output_code(
 		if(*code == '$' && code[1] >= first && code[1] < (first + MAX_PATTERN))
 		{
 			index = code[1] - first;
-			printf(names[index]);
+			printf("%s", names[index]);
 			code += 2;
 		}
 		else if(*code == '%' && code[1] >= first && code[1] < (first + MAX_PATTERN))
 		{
 			index = code[1] - first;
-			printf(other_names[index]);
+			printf("%s", other_names[index]);
 			code += 2;
 		}
 		else if(*code == '\n')

--- a/tools/gen-rules-parser.y
+++ b/tools/gen-rules-parser.y
@@ -73,7 +73,7 @@ gensel_error(char *filename, long linenum, char *msg)
  * Report error messages from the parser.
  */
 static void
-yyerror(char *msg)
+yyerror(const char *msg)
 {
 	gensel_error_message(gensel_filename, gensel_linenum, msg);
 }


### PR DESCRIPTION
I am trying to build an RPM for libjit. The default CFLAGS when building an RPM include -Werror=format-security, and that causes a build failure:

```
gcc -DHAVE_CONFIG_H -I. -I..    -I../include -I../include -I../jit -I../jit -fno-gcse -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -Wall -fno-omit-frame-pointer -c -o gen-rules-parser.o gen-rules-parser.c
gen-rules-parser.y: In function ‘gensel_output_code’:
gen-rules-parser.y:862:4: error: format not a string literal and no format arguments [-Werror=format-security]
    printf(names[index]);
    ^~~~~~
gen-rules-parser.y:868:4: error: format not a string literal and no format arguments [-Werror=format-security]
    printf(other_names[index]);
    ^~~~~~
gen-rules-parser.c: In function ‘yyparse’:
gen-rules-parser.c:3619:18: warning: passing argument 1 of ‘yyerror’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
         yyerror (yymsgp);
                  ^~~~~~
gen-rules-parser.y:76:1: note: expected ‘char *’ but argument is of type ‘const char *’
 yyerror(char *msg)
 ^~~~~~~
cc1: some warnings being treated as errors
```

There are a few of these related to some basic errors around printf and const correctness, which this fixes. Note that I am still working through other compiler errors, this branch is not sufficient.