### PR TITLE
add missing memory load when memcpy'ing small structs on x86-64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-03-01  Jakob Löw  <jakob@m4gnus.de>
+
+	* jit/jit-rules-x86-64.c: Fix copying small blocks when the size is not a
+	multiple of 16.
+
 2018-02-10  Evan Klitzke  <evan@eklitzke.org>
 
 	* README: fix some typos.

--- a/jit/jit-rules-x86-64.c
+++ b/jit/jit-rules-x86-64.c
@@ -2645,6 +2645,8 @@ small_block_copy(jit_gencode_t gen, unsigned char *inst,
 	{
 		if(size >= i)
 		{
+			x86_64_mov_reg_membase_size(inst, scratch_reg, sreg,
+										soffset + offset, i);
 			x86_64_mov_membase_reg_size(inst, dreg, doffset + offset,
 										scratch_reg, i);
 			size -= i;


### PR DESCRIPTION
hmm according to git blame this one is on me, i kind of feel bad for not noticing it.