### PR TITLE
Implementing Nesting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2018-08-28  Jakob Löw  <jakob@m4gnus.de>
+
+	* jit-insn.c, jit-insn.h, jit-function.c, jit-function.h, jit-internal.h:
+	  implement nesting using retrieve_frame_pointer and the frame_offset of
+	  values. The frame pointer can either be passed automatically to child
+	  functions when e.g. using jit_insn_call or manually using the new
+	  functions jit_insn_call_nested_indirect, jit_insn_get_frame_pointer,
+	  jit_insn_get_parent_frame_pointer_of or jit_function_set_parent_frame.
+	* jit-rules-*.ins: implement the retrieve_frame_pointer opcode.
+
 2018-03-22  Aleksey Demakov  <ademakov@gmail.com>
 
 	* tests/misc/minimal.c: add David Meyer's test for a global register

--- a/attic/jit-rules-alpha.ins
+++ b/attic/jit-rules-alpha.ins
@@ -450,6 +450,11 @@ JIT_OP_RETURN_REG: manual
 		/* Nothing to do here */;
 	}
 
+JIT_OP_RETRIEVE_FRAME_POINTER: note
+	[=reg] -> {
+		alpha_mov(inst,$1,ALPHA_FP);
+	}
+
 JIT_OP_PUSH_INT: note
 	[imm] -> {
 		alpha_li(inst,ALPHA_AT,$1);

--- a/include/jit/jit-function.h
+++ b/include/jit/jit-function.h
@@ -51,6 +51,8 @@ jit_function_t jit_function_previous
 jit_block_t jit_function_get_entry(jit_function_t func) JIT_NOTHROW;
 jit_block_t jit_function_get_current(jit_function_t func) JIT_NOTHROW;
 jit_function_t jit_function_get_nested_parent(jit_function_t func) JIT_NOTHROW;
+void jit_function_set_parent_frame(jit_function_t func,
+	jit_value_t parent_frame) JIT_NOTHROW;
 int jit_function_compile(jit_function_t func) JIT_NOTHROW;
 int jit_function_is_compiled(jit_function_t func) JIT_NOTHROW;
 void jit_function_set_recompilable(jit_function_t func) JIT_NOTHROW;

--- a/include/jit/jit-insn.h
+++ b/include/jit/jit-insn.h
@@ -255,6 +255,9 @@ int jit_insn_return_reg
 int jit_insn_setup_for_nested
 	(jit_function_t func, int nested_level, int reg) JIT_NOTHROW;
 int jit_insn_flush_struct(jit_function_t func, jit_value_t value) JIT_NOTHROW;
+jit_value_t jit_insn_get_frame_pointer(jit_function_t func) JIT_NOTHROW;
+jit_value_t jit_insn_get_parent_frame_of
+	(jit_function_t func, jit_value_t frame_pointer) JIT_NOTHROW;
 jit_value_t jit_insn_import
 	(jit_function_t func, jit_value_t value) JIT_NOTHROW;
 int jit_insn_push(jit_function_t func, jit_value_t value) JIT_NOTHROW;

--- a/include/jit/jit-insn.h
+++ b/include/jit/jit-insn.h
@@ -256,8 +256,8 @@ int jit_insn_setup_for_nested
 	(jit_function_t func, int nested_level, int reg) JIT_NOTHROW;
 int jit_insn_flush_struct(jit_function_t func, jit_value_t value) JIT_NOTHROW;
 jit_value_t jit_insn_get_frame_pointer(jit_function_t func) JIT_NOTHROW;
-jit_value_t jit_insn_get_parent_frame_of
-	(jit_function_t func, jit_value_t frame_pointer) JIT_NOTHROW;
+jit_value_t jit_insn_get_parent_frame_pointer_of
+	(jit_function_t func, jit_function_t target) JIT_NOTHROW;
 jit_value_t jit_insn_import
 	(jit_function_t func, jit_value_t value) JIT_NOTHROW;
 int jit_insn_push(jit_function_t func, jit_value_t value) JIT_NOTHROW;

--- a/include/jit/jit-insn.h
+++ b/include/jit/jit-insn.h
@@ -231,6 +231,10 @@ jit_value_t jit_insn_call
 jit_value_t jit_insn_call_indirect
 	(jit_function_t func, jit_value_t value, jit_type_t signature,
 	 jit_value_t *args, unsigned int num_args, int flags) JIT_NOTHROW;
+jit_value_t jit_insn_call_nested_indirect
+	(jit_function_t func, jit_value_t value, jit_value_t parent_frame,
+	 jit_type_t signature, jit_value_t *args, unsigned int num_args,
+	 int flags) JIT_NOTHROW;
 jit_value_t jit_insn_call_indirect_vtable
 	(jit_function_t func, jit_value_t value, jit_type_t signature,
 	 jit_value_t *args, unsigned int num_args, int flags) JIT_NOTHROW;

--- a/jit/jit-compile.c
+++ b/jit/jit-compile.c
@@ -222,15 +222,6 @@ compile_block(jit_gencode_t gen, jit_function_t func, jit_block_t block)
 			break;
 #endif
 
-		case JIT_OP_IMPORT:
-			_jit_gen_fix_value(insn->value2);
-			insn->opcode = JIT_OP_ADD_RELATIVE;
-			insn->value2 = jit_value_create_nint_constant(func, jit_type_nint,
-				insn->value2->frame_offset);
-
-			_jit_gen_insn(gen, func, block, insn);
-			break;
-
 #ifndef JIT_BACKEND_INTERP
 		case JIT_OP_INCOMING_REG:
 			/* Assign a register to an incoming value */

--- a/jit/jit-compile.c
+++ b/jit/jit-compile.c
@@ -223,6 +223,22 @@ compile_block(jit_gencode_t gen, jit_function_t func, jit_block_t block)
 #endif
 
 #ifndef JIT_BACKEND_INTERP
+		case JIT_OP_IMPORT:
+			/* Make sure the import target has a frame_offset */
+			_jit_gen_fix_value(insn->value2);
+
+			/* change the current instruction to an instruction calculating the
+			   address of the import target */
+			insn->opcode = JIT_OP_ADD_RELATIVE;
+			insn->value2 = jit_value_create_nint_constant(func, jit_type_nint,
+				insn->value2->frame_offset);
+
+			/* generate the instruction */
+			_jit_gen_insn(gen, func, block, insn);
+			break;
+#endif
+
+#ifndef JIT_BACKEND_INTERP
 		case JIT_OP_INCOMING_REG:
 			/* Assign a register to an incoming value */
 			_jit_regs_set_incoming(gen,

--- a/jit/jit-compile.c
+++ b/jit/jit-compile.c
@@ -222,6 +222,15 @@ compile_block(jit_gencode_t gen, jit_function_t func, jit_block_t block)
 			break;
 #endif
 
+		case JIT_OP_IMPORT:
+			_jit_gen_fix_value(insn->value2);
+			insn->opcode = JIT_OP_ADD_RELATIVE;
+			insn->value2 = jit_value_create_nint_constant(func, jit_type_nint,
+				insn->value2->frame_offset);
+
+			_jit_gen_insn(gen, func, block, insn);
+			break;
+
 #ifndef JIT_BACKEND_INTERP
 		case JIT_OP_INCOMING_REG:
 			/* Assign a register to an incoming value */
@@ -463,7 +472,7 @@ memory_start(_jit_compile_t *state)
 
 	/* Store the bounds of the available space */
 	state->gen.mem_start = _jit_memory_get_break(state->gen.context);
-	state->gen.mem_limit = _jit_memory_get_limit(state->gen.context); 
+	state->gen.mem_limit = _jit_memory_get_limit(state->gen.context);
 
 	/* Align the function code start as required */
 	state->gen.ptr = state->gen.mem_start;

--- a/jit/jit-compile.c
+++ b/jit/jit-compile.c
@@ -274,16 +274,6 @@ compile_block(jit_gencode_t gen, jit_function_t func, jit_block_t block)
 			break;
 #endif
 
-		case JIT_OP_OUTGOING_FRAME_POSN:
-			/* Set the frame position for an outgoing value */
-			insn->value1->frame_offset = jit_value_get_nint_constant(insn->value2);
-			insn->value1->in_register = 0;
-			insn->value1->in_global_register = 0;
-			insn->value1->in_frame = 0;
-			insn->value1->has_frame_offset = 1;
-			insn->value1->has_global_register = 0;
-			break;
-
 #ifndef JIT_BACKEND_INTERP
 		case JIT_OP_RETURN_REG:
 			/* Assign a register to a return value */

--- a/jit/jit-dump.c
+++ b/jit/jit-dump.c
@@ -794,7 +794,8 @@ void jit_dump_function(FILE *stream, jit_function_t func, const char *name)
 			putc('[', stream);
 			if(func->nested_parent)
 			{
-				fputs("parent_frame", stream);
+				jit_dump_value(stream, func, func->parent_frame, 0);
+				fputs(" : parent_frame", stream);
 				if(value)
 				{
 					fputs(", ", stream);

--- a/jit/jit-dump.c
+++ b/jit/jit-dump.c
@@ -782,19 +782,19 @@ void jit_dump_function(FILE *stream, jit_function_t func, const char *name)
 		{
 			/* We have extra hidden parameters */
 			putc('[', stream);
-			if(func->nested_parent)
-			{
-				jit_dump_value(stream, func, func->parent_frame, 0);
-				fputs(" : parent_frame", stream);
-				if(value)
-				{
-					fputs(", ", stream);
-				}
-			}
 			if(value)
 			{
 				jit_dump_value(stream, func, value, 0);
 				fputs(" : struct_ptr", stream);
+				if(func->nested_parent)
+				{
+					fputs(", ", stream);
+				}
+			}
+			if(func->nested_parent)
+			{
+				jit_dump_value(stream, func, func->parent_frame, 0);
+				fputs(" : parent_frame", stream);
 			}
 			putc(']', stream);
 			if(num_params > 0)

--- a/jit/jit-function.c
+++ b/jit/jit-function.c
@@ -130,9 +130,7 @@ jit_function_create(jit_context_t context, jit_type_t signature)
  * @var{parent} function and is able to access its parent's
  * (and grandparent's) local variables.
  *
- * The front end is responsible for ensuring that the nested function can
- * never be called by anyone except its parent and sibling functions.
- * The front end is also responsible for ensuring that the nested function
+ * The front end is responsible for ensuring that the nested function
  * is compiled before its parent.
  * @end deftypefun
 @*/

--- a/jit/jit-function.c
+++ b/jit/jit-function.c
@@ -500,6 +500,19 @@ jit_function_t jit_function_get_nested_parent(jit_function_t func)
 	}
 }
 
+/*@
+ * @deftypefun jit_function_t jit_function_get_nested_parent (jit_function_t @var{func}, jit_value_t @var{parent_frame})
+ * Set the frame pointer of the parent of a nested function
+ * @end deftypefun
+@*/
+void jit_function_set_parent_frame(jit_function_t func,
+	jit_value_t parent_frame)
+{
+	func->parent_frame = parent_frame;
+	func->cached_parent = NULL;
+	func->cached_parent_frame = NULL;
+}
+
 /*
  * Information that is stored for an exception region in the cache.
  */
@@ -645,7 +658,7 @@ void *jit_function_to_closure(jit_function_t func)
  * closure does not correspond to a function in the specified context.
  * @end deftypefun
 @*/
-jit_function_t 
+jit_function_t
 jit_function_from_closure(jit_context_t context, void *closure)
 {
 	void *func_info;

--- a/jit/jit-insn.c
+++ b/jit/jit-insn.c
@@ -6292,34 +6292,8 @@ jit_insn_flush_struct(jit_function_t func, jit_value_t value)
 jit_value_t
 jit_insn_get_frame_pointer(jit_function_t func)
 {
-	int reg;
-	jit_value_t value;
-
-	value = jit_value_create(func, jit_type_void_ptr);
-	if(!value)
-	{
-		return 0;
-	}
-
-	for(reg = 0; reg < JIT_NUM_REGS; reg++)
-	{
-		if(jit_reg_flags(reg) & JIT_REG_FRAME)
-		{
-			break;
-		}
-	}
-
-	if(reg < JIT_NUM_REGS)
-	{
-		jit_insn_incoming_reg(func, value, reg);
-	}
-	else
-	{
-		jit_insn_incoming_frame_posn(func, value, 0);
-		value = jit_insn_address_of(func, value);
-	}
-
-	return value;
+	return create_dest_note(func, JIT_OP_RETRIEVE_FRAME_POINTER,
+		jit_type_void_ptr);
 }
 
 static jit_value_t

--- a/jit/jit-insn.c
+++ b/jit/jit-insn.c
@@ -6308,7 +6308,16 @@ jit_insn_get_frame_pointer(jit_function_t func)
 			break;
 		}
 	}
-	jit_insn_incoming_reg(func, value, reg);
+
+	if(reg < JIT_NUM_REGS)
+	{
+		jit_insn_incoming_reg(func, value, reg);
+	}
+	else
+	{
+		jit_insn_incoming_frame_posn(func, value, 0);
+		value = jit_insn_address_of(func, value);
+	}
 
 	return value;
 }

--- a/jit/jit-insn.c
+++ b/jit/jit-insn.c
@@ -6292,17 +6292,25 @@ jit_insn_flush_struct(jit_function_t func, jit_value_t value)
 jit_value_t
 jit_insn_get_frame_pointer(jit_function_t func)
 {
-	jit_value_t dummy;
+	int reg;
+	jit_value_t value;
 
-	dummy = jit_value_create(func, jit_type_sbyte);
-	if(!dummy)
+	value = jit_value_create(func, jit_type_void_ptr);
+	if(!value)
 	{
 		return 0;
 	}
-	jit_value_set_addressable(dummy);
 
-	jit_insn_incoming_frame_posn(func, dummy, 0);
-	return jit_insn_address_of(func, dummy);
+	for(reg = 0; reg < JIT_NUM_REGS; reg++)
+	{
+		if(jit_reg_flags(reg) & JIT_REG_FRAME)
+		{
+			break;
+		}
+	}
+	jit_insn_incoming_reg(func, value, reg);
+
+	return value;
 }
 
 static jit_value_t

--- a/jit/jit-internal.h
+++ b/jit/jit-internal.h
@@ -466,6 +466,7 @@ struct _jit_function
 	jit_value_t		parent_frame;
 #ifdef JIT_BACKEND_INTERP
 	jit_value_t		arguments_pointer;
+	jit_nint		arguments_pointer_offset;
 #endif
 	jit_function_t		cached_parent;
 	jit_value_t		cached_parent_frame;

--- a/jit/jit-internal.h
+++ b/jit/jit-internal.h
@@ -463,6 +463,9 @@ struct _jit_function
 
 	/* Containing function in a nested context */
 	jit_function_t		nested_parent;
+	jit_value_t		parent_frame;
+	jit_function_t		cached_parent;
+	jit_value_t		cached_parent_frame;
 
 	/* Metadata that survives once the builder is discarded */
 	jit_meta_t		meta;

--- a/jit/jit-internal.h
+++ b/jit/jit-internal.h
@@ -464,6 +464,9 @@ struct _jit_function
 	/* Containing function in a nested context */
 	jit_function_t		nested_parent;
 	jit_value_t		parent_frame;
+#ifdef JIT_BACKEND_INTERP
+	jit_value_t		arguments_pointer;
+#endif
 	jit_function_t		cached_parent;
 	jit_value_t		cached_parent_frame;
 

--- a/jit/jit-interp-opcodes.ops
+++ b/jit/jit-interp-opcodes.ops
@@ -179,11 +179,6 @@ opcodes(JIT_INTERP_OP_,
 	op_def("pop_2") { }
 	op_def("pop_3") { }
 	/*
-	 * Nested function call handling.
-	 */
-	op_def("import_local") { "JIT_OPCODE_NINT_ARG_TWO" }
-	op_def("import_arg") { "JIT_OPCODE_NINT_ARG_TWO" }
-	/*
 	 * Marker opcode for the end of a function.
 	 */
 	op_def("end_marker") { }

--- a/jit/jit-interp.c
+++ b/jit/jit-interp.c
@@ -3595,68 +3595,6 @@ restart_tail:
 		}
 		/* Not reached */
 
-		VMCASE(JIT_OP_SETUP_FOR_NESTED):
-		{
-			/* TODO!!! */
-			/* Set up to call a nested function who is our child */
-			stacktop[-1].ptr_value = args;
-			stacktop[-2].ptr_value = frame;
-			VM_MODIFY_PC_AND_STACK(1, -2);
-		}
-		VMBREAK;
-
-		VMCASE(JIT_OP_SETUP_FOR_SIBLING):
-		{
-			/* TODO!!! */
-			/* Set up to call a nested function who is our sibling, a sibling
-			   of one of our ancestors, or one of our ancestors directly */
-			temparg = VM_NINT_ARG;
-			tempptr = &(args[0]);
-			while(temparg > 0)
-			{
-				tempptr = (((jit_item *)tempptr)[1]).ptr_value;
-				--temparg;
-			}
-			stacktop[-1].ptr_value = (((jit_item *)tempptr)[1]).ptr_value;
-			stacktop[-2].ptr_value = (((jit_item *)tempptr)[0]).ptr_value;
-			VM_MODIFY_PC_AND_STACK(1, -2);
-		}
-		VMBREAK;
-
-		VMCASE(JIT_INTERP_OP_IMPORT_LOCAL):
-		{
-			/* TODO!!! */
-			/* Import the address of a local variable from an outer scope */
-			temparg = VM_NINT_ARG2;
-			tempptr = args[0].ptr_value;
-			tempptr2 = args[1].ptr_value;
-			while(temparg > 1)
-			{
-				tempptr = ((jit_item *)tempptr2)[0].ptr_value;
-				tempptr2 = ((jit_item *)tempptr2)[1].ptr_value;
-				--temparg;
-			}
-			VM_R0_PTR = ((jit_item *)tempptr) + VM_NINT_ARG;
-			VM_MODIFY_PC(3);
-		}
-		VMBREAK;
-
-		VMCASE(JIT_INTERP_OP_IMPORT_ARG):
-		{
-			/* TODO!!! */
-			/* Import the address of an argument from an outer scope */
-			temparg = VM_NINT_ARG2;
-			tempptr = args[1].ptr_value;
-			while(temparg > 1)
-			{
-				tempptr = ((jit_item *)tempptr)[1].ptr_value;
-				--temparg;
-			}
-			VM_R0_PTR = ((jit_item *)tempptr) + VM_NINT_ARG;
-			VM_MODIFY_PC(3);
-		}
-		VMBREAK;
-
 		VMCASE(JIT_OP_PUSH_INT):
 		{
 			VM_STK_INTP = VM_R1_INT;
@@ -5013,7 +4951,6 @@ restart_tail:
 		 * by more specific instructions during function compilation.
 		 ******************************************************************/
 
-		VMCASE(JIT_OP_IMPORT):
 		VMCASE(JIT_OP_COPY_LOAD_SBYTE):
 		VMCASE(JIT_OP_COPY_LOAD_UBYTE):
 		VMCASE(JIT_OP_COPY_LOAD_SHORT):

--- a/jit/jit-interp.c
+++ b/jit/jit-interp.c
@@ -4892,6 +4892,14 @@ restart_tail:
 		 * Stack management.
 		 ******************************************************************/
 
+		VMCASE(JIT_OP_RETRIEVE_FRAME_POINTER):
+		{
+			/* Move the frame pointer into the register 0 */
+			VM_R0_PTR = frame;
+			VM_MODIFY_PC(1);
+		}
+		VMBREAK;
+
 		VMCASE(JIT_OP_POP_STACK):
 		{
 			/* Pop a specific number of items from the stack */

--- a/jit/jit-interp.c
+++ b/jit/jit-interp.c
@@ -350,6 +350,11 @@ restart_tail:
 		jbuf = 0;
 	}
 
+	if(func->func->arguments_pointer)
+	{
+		frame[func->func->arguments_pointer->frame_offset].ptr_value = args;
+	}
+
 	/* Enter the instruction dispatch loop */
 	VMSWITCH(pc)
 	{

--- a/jit/jit-interp.c
+++ b/jit/jit-interp.c
@@ -309,6 +309,7 @@ void _jit_run_function(jit_function_interp_t func, jit_item *args,
 	jit_nint temparg;
 	void *tempptr;
 	void *tempptr2;
+	jit_nint arguments_pointer_offset;
 	jit_function_t call_func;
 	struct jit_backtrace call_trace;
 	void *entry;
@@ -350,9 +351,10 @@ restart_tail:
 		jbuf = 0;
 	}
 
-	if(func->func->arguments_pointer)
+	arguments_pointer_offset = func->func->arguments_pointer_offset;
+	if(arguments_pointer_offset >= 0)
 	{
-		frame[func->func->arguments_pointer->frame_offset].ptr_value = args;
+		frame[arguments_pointer_offset].ptr_value = args;
 	}
 
 	/* Enter the instruction dispatch loop */
@@ -4964,6 +4966,7 @@ restart_tail:
 		 * by more specific instructions during function compilation.
 		 ******************************************************************/
 
+		VMCASE(JIT_OP_IMPORT):
 		VMCASE(JIT_OP_COPY_LOAD_SBYTE):
 		VMCASE(JIT_OP_COPY_LOAD_UBYTE):
 		VMCASE(JIT_OP_COPY_LOAD_SHORT):

--- a/jit/jit-opcodes.ops
+++ b/jit/jit-opcodes.ops
@@ -797,6 +797,7 @@ opcodes(JIT_OP_, "jit_opcode_info_t const jit_opcodes[JIT_OP_NUM_OPCODES]")
 	op_def("outgoing_reg") { op_type(reg) }
 	op_def("outgoing_frame_posn") { op_values(empty, any, int) }
 	op_def("return_reg") { op_type(reg) }
+	op_def("retrieve_frame_pointer") { op_values(any, empty, empty) }
 	op_def("push_int") { op_values(empty, int) }
 	op_def("push_long") { op_values(empty, long) }
 	op_def("push_float32") { op_values(empty, float32) }

--- a/jit/jit-opcodes.ops
+++ b/jit/jit-opcodes.ops
@@ -758,9 +758,6 @@ opcodes(JIT_OP_, "jit_opcode_info_t const jit_opcodes[JIT_OP_NUM_OPCODES]")
 	op_def("return_float64") { op_values(empty, float64) }
 	op_def("return_nfloat") { op_values(empty, nfloat) }
 	op_def("return_small_struct") { op_values(empty, ptr, ptr), "NINT_ARG" }
-	op_def("setup_for_nested") { op_values(empty, int) }
-	op_def("setup_for_sibling") { op_values(empty, int, int), "NINT_ARG" }
-	op_def("import") { op_values(ptr, any, int) }
 	/*
 	 * Exception handling.
 	 */

--- a/jit/jit-opcodes.ops
+++ b/jit/jit-opcodes.ops
@@ -796,7 +796,6 @@ opcodes(JIT_OP_, "jit_opcode_info_t const jit_opcodes[JIT_OP_NUM_OPCODES]")
 	op_def("incoming_reg") { op_type(reg) }
 	op_def("incoming_frame_posn") { op_values(empty, any, int) }
 	op_def("outgoing_reg") { op_type(reg) }
-	op_def("outgoing_frame_posn") { op_values(empty, any, int) }
 	op_def("return_reg") { op_type(reg) }
 	op_def("retrieve_frame_pointer") { op_values(any, empty, empty) }
 	op_def("push_int") { op_values(empty, int) }

--- a/jit/jit-opcodes.ops
+++ b/jit/jit-opcodes.ops
@@ -758,6 +758,7 @@ opcodes(JIT_OP_, "jit_opcode_info_t const jit_opcodes[JIT_OP_NUM_OPCODES]")
 	op_def("return_float64") { op_values(empty, float64) }
 	op_def("return_nfloat") { op_values(empty, nfloat) }
 	op_def("return_small_struct") { op_values(empty, ptr, ptr), "NINT_ARG" }
+	op_def("import") { op_values(ptr, any, any) }
 	/*
 	 * Exception handling.
 	 */

--- a/jit/jit-rules-arm.ins
+++ b/jit/jit-rules-arm.ins
@@ -1321,6 +1321,11 @@ JIT_OP_INCOMING_REG, JIT_OP_RETURN_REG: note
 		 * and free the register if the value is dead.
 		 */
 	}
+
+JIT_OP_RETRIEVE_FRAME_POINTER: note
+	[=reg] -> {
+		arm_mov_reg_reg(inst, $1, ARM_FP);
+	}
 	
 JIT_OP_PUSH_INT: note
 	[reg] -> {

--- a/jit/jit-rules-arm.ins
+++ b/jit/jit-rules-arm.ins
@@ -1037,51 +1037,6 @@ JIT_OP_RETURN_SMALL_STRUCT: note
 		jump_to_epilog(gen, &inst, block);
 	}
 
-JIT_OP_SETUP_FOR_NESTED: /*spill_before*/
-	[] -> {
-		jit_nint nest_reg = jit_value_get_nint_constant(insn->value1);
-		if(nest_reg == -1)
-		{
-			arm_push_reg(inst, ARM_FP);
-		}
-		else
-		{
-			arm_mov_reg_reg(inst, _jit_reg_info[nest_reg].cpu_reg, ARM_FP);
-		}
-	}
-
-JIT_OP_SETUP_FOR_SIBLING: /*spill_before*/
-	[] -> {
-		jit_nint level = jit_value_get_nint_constant(insn->value1);
-		jit_nint nest_reg = jit_value_get_nint_constant(insn->value2);
-		int cpu_reg;
-		if(nest_reg == -1)
-		{
-			cpu_reg = ARM_R0;
-		}
-		else
-		{
-			cpu_reg = _jit_reg_info[nest_reg].cpu_reg;
-		}
-		arm_load_membase(inst, cpu_reg, ARM_FP, JIT_APPLY_PARENT_FRAME_OFFSET);
-		while(level > 0)
-		{
-			arm_load_membase(inst, cpu_reg, cpu_reg,
-							 JIT_APPLY_PARENT_FRAME_OFFSET);
-			--level;
-		}
-		if(nest_reg == -1)
-		{
-			arm_push_reg(inst, cpu_reg);
-		}
-	}
-
-JIT_OP_IMPORT:
-	[] -> {
-		/* TODO */
-		TODO();
-	}
-
 /*
  * Exception handling
  */

--- a/jit/jit-rules-interp.c
+++ b/jit/jit-rules-interp.c
@@ -287,11 +287,18 @@ int _jit_create_entry_insns(jit_function_t func)
 	   flipped when we output the argument opcodes for interpretation */
 	offset = -1;
 
-	/* If the function is nested, then we need two extra parameters
-	   to pass the pointer to the parent's local variables and arguments */
+	/* If the function is nested, then we an extra parameter
+	   to pass the pointer to the parent's frame */
 	if(func->nested_parent)
 	{
-		offset -= 2;
+		value = jit_value_create(func, jit_type_void_ptr);
+		if(!jit_insn_incoming_frame_posn(func, value, offset))
+		{
+			return 0;
+		}
+
+		jit_function_set_parent_frame(func, value);
+		--offset;
 	}
 
 	/* Allocate the structure return pointer */
@@ -974,7 +981,7 @@ load_value(jit_gencode_t gen, jit_value_t value, int index)
 			default:
 				return;
 			}
-			opcode = _jit_load_opcode(opcode, value->type, value, 0);
+			opcode = _jit_load_opcode(opcode, value->type);
 			offset = value->frame_offset;
 		}
 		else
@@ -994,7 +1001,7 @@ load_value(jit_gencode_t gen, jit_value_t value, int index)
 			default:
 				return;
 			}
-			opcode = _jit_load_opcode(opcode, value->type, value, 0);
+			opcode = _jit_load_opcode(opcode, value->type);
 			offset = -(value->frame_offset + 1);
 		}
 

--- a/jit/jit-rules-interp.c
+++ b/jit/jit-rules-interp.c
@@ -1254,39 +1254,6 @@ void _jit_gen_insn(jit_gencode_t gen, jit_function_t func,
 		jit_cache_native(gen, jit_value_get_nint_constant(insn->value2));
 		break;
 
-	case JIT_OP_SETUP_FOR_NESTED:
-		/* TODO!!! */
-		/* Set up to call a nested child */
-		jit_cache_opcode(gen, insn->opcode);
-		adjust_working(gen, 2);
-		break;
-
-	case JIT_OP_SETUP_FOR_SIBLING:
-		/* TODO!!! */
-		/* Set up to call a nested sibling */
-		jit_cache_opcode(gen, insn->opcode);
-		jit_cache_native(gen, jit_value_get_nint_constant(insn->value1));
-		adjust_working(gen, 2);
-		break;
-
-	case JIT_OP_IMPORT:
-		/* Import a local variable from an outer nested scope */
-		_jit_gen_fix_value(insn->value1);
-		if(insn->value1->frame_offset >= 0)
-		{
-			jit_cache_opcode(gen, JIT_INTERP_OP_IMPORT_LOCAL);
-			jit_cache_native(gen, insn->value1->frame_offset);
-			jit_cache_native(gen, jit_value_get_nint_constant(insn->value2));
-		}
-		else
-		{
-			jit_cache_opcode(gen, JIT_INTERP_OP_IMPORT_ARG);
-			jit_cache_native(gen, -(insn->value1->frame_offset + 1));
-			jit_cache_native(gen, jit_value_get_nint_constant(insn->value2));
-		}
-		store_value(gen, insn->dest);
-		break;
-
 	case JIT_OP_THROW:
 		/* Throw an exception */
 		load_value(gen, insn->value1, 1);

--- a/jit/jit-rules-x86-64.ins
+++ b/jit/jit-rules-x86-64.ins
@@ -388,6 +388,11 @@ JIT_OP_INCOMING_REG, JIT_OP_RETURN_REG: note
 		 */
 	}
 
+JIT_OP_RETRIEVE_FRAME_POINTER: note
+	[=reg] -> {
+		x86_64_mov_reg_reg_size(inst, $1, X86_64_RBP, 8);
+	}
+
 JIT_OP_PUSH_INT: note
 	[imm] -> {
 		x86_64_push_imm(inst, $1);

--- a/jit/jit-rules-x86.ins
+++ b/jit/jit-rules-x86.ins
@@ -19,7 +19,7 @@
  * License along with the libjit library.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
- 
+
 %regclass reg x86_reg
 %regclass breg x86_breg
 %regclass freg x86_freg
@@ -123,7 +123,7 @@ JIT_OP_LOW_WORD:
 			x86_mov_reg_reg(inst, $1, $2, 4);
 		}
 	}
-	
+
 JIT_OP_EXPAND_INT:
 	[=lreg, reg] -> {
 		if($1 != $2)
@@ -1800,89 +1800,6 @@ JIT_OP_RETURN_SMALL_STRUCT: note
 		inst = jump_to_epilog(gen, inst, block);
 	}
 
-JIT_OP_SETUP_FOR_NESTED: branch
-	[] -> {
-		jit_nint nest_reg = jit_value_get_nint_constant(insn->value1);
-		if(nest_reg == -1)
-		{
-			x86_push_reg(inst, X86_EBP);
-		}
-		else
-		{
-			x86_mov_reg_reg(inst, _jit_reg_info[nest_reg].cpu_reg,
-							X86_EBP, sizeof(void *));
-		}
-	}
-
-JIT_OP_SETUP_FOR_SIBLING: branch
-	[] -> {
-		jit_value_t parent;
-		jit_nint level = jit_value_get_nint_constant(insn->value1);
-		jit_nint nest_reg = jit_value_get_nint_constant(insn->value2);
-		int cpu_reg;
-		if(nest_reg == -1)
-		{
-			cpu_reg = X86_EAX;
-		}
-		else
-		{
-			cpu_reg = _jit_reg_info[nest_reg].cpu_reg;
-		}
-		parent = func->builder->parent_frame;
-		if(parent->in_register)
-		{
-			x86_mov_reg_reg(inst, cpu_reg,
-							_jit_reg_info[parent->reg].cpu_reg,
-							sizeof(void *));
-		}
-		else if(parent->in_global_register)
-		{
-			x86_mov_reg_reg(inst, cpu_reg,
-							_jit_reg_info[parent->global_reg].cpu_reg,
-							sizeof(void *));
-		}
-		else
-		{
-			_jit_gen_fix_value(parent);
-			x86_mov_reg_membase(inst, cpu_reg, X86_EBP,
-							    parent->frame_offset, sizeof(void *));
-		}
-		while(level > 0)
-		{
-			gen->ptr = inst;
-			_jit_gen_check_space(gen, 16);
-			x86_mov_reg_membase(inst, cpu_reg, cpu_reg, 0, sizeof(void *));
-			--level;
-		}
-		if(nest_reg == -1)
-		{
-			x86_push_reg(inst, cpu_reg);
-		}
-	}
-
-JIT_OP_IMPORT: manual
-	[] -> {
-		unsigned char *inst;
-		int reg;
-		jit_nint level = jit_value_get_nint_constant(insn->value2);
-		_jit_gen_fix_value(insn->value1);
-		reg = _jit_regs_load_value
-			(gen, func->builder->parent_frame, 1, 0);
-		inst = gen->ptr;
-		_jit_gen_check_space(gen, 32 + level * 8);
-		reg = _jit_reg_info[reg].cpu_reg;
-		while(level > 0)
-		{
-			x86_mov_reg_membase(inst, reg, reg, 0, sizeof(void *));
-			--level;
-		}
-		if(insn->value1->frame_offset != 0)
-		{
-			x86_alu_reg_imm(inst, X86_ADD, reg, insn->value1->frame_offset);
-		}
-		gen->ptr = inst;
-	}
-
 /*
  * Exception handling.
  */
@@ -2266,7 +2183,7 @@ JIT_OP_LOAD_RELATIVE_FLOAT64:
 	[=freg, reg, imm] -> {
 		x86_fld_membase(inst, $2, $3, 1);
 	}
-	
+
 JIT_OP_LOAD_RELATIVE_NFLOAT:
 	[=freg, reg, imm, if("sizeof(jit_nfloat) != sizeof(jit_float64)")] -> {
 		x86_fld80_membase(inst, $2, $3);

--- a/jit/jit-rules-x86.ins
+++ b/jit/jit-rules-x86.ins
@@ -1993,6 +1993,11 @@ JIT_OP_INCOMING_REG, JIT_OP_RETURN_REG: note
 		 */
 	}
 
+JIT_OP_RETRIEVE_FRAME_POINTER: note
+	[=reg] -> {
+		x86_mov_reg_reg(inst, $1, X86_EBP, 4);
+	}
+
 JIT_OP_PUSH_INT: note
 	[imm] -> {
 		x86_push_imm(inst, $1);

--- a/jit/jit-rules.c
+++ b/jit/jit-rules.c
@@ -506,6 +506,10 @@ int _jit_create_call_setup_insns
 
 	/* Determine how many parameters are going to end up in word registers,
 	   and compute the largest stack size needed to pass stack parameters */
+	if(is_nested)
+	{
+		need_outgoing_word(&passing);
+	}
 	type = jit_type_get_return(signature);
 	if(jit_type_return_via_pointer(type))
 	{
@@ -526,10 +530,6 @@ int _jit_create_call_setup_insns
 	{
 		*struct_return = 0;
 		return_ptr = 0;
-	}
-	if(is_nested)
-	{
-		need_outgoing_word(&passing);
 	}
 	partial = 0;
 	for(param = 0; param < num_args; ++param)

--- a/jit/jit-rules.c
+++ b/jit/jit-rules.c
@@ -172,7 +172,8 @@ int _jit_create_entry_insns(jit_function_t func)
 		{
 			return 0;
 		}
-		func->builder->parent_frame = value;
+
+		jit_function_set_parent_frame(func, value);
 		if(!alloc_incoming_word(func, &passing, value, 0))
 		{
 			return 0;

--- a/jit/jit-rules.h
+++ b/jit/jit-rules.h
@@ -212,7 +212,7 @@ int _jit_create_entry_insns(jit_function_t func);
 int _jit_create_call_setup_insns
 	(jit_function_t func, jit_type_t signature,
 	 jit_value_t *args, unsigned int num_args,
-	 int is_nested, int nesting_level, jit_value_t *struct_return, int flags);
+	 int is_nested, jit_value_t parent_frame, jit_value_t *struct_return, int flags);
 int _jit_setup_indirect_pointer(jit_function_t func, jit_value_t value);
 int _jit_create_call_return_insns
 	(jit_function_t func, jit_type_t signature,


### PR DESCRIPTION
In upstream libjit nesting is mostly unimplemented. There are the import related opcodes but no backend except x86 (32-bit Intel) implements them.
The commits in this pull request implement nesting, mostly in the front end. It removes all import related opcodes and adds one new one to retrieve a functions frame pointer. The frame pointer is then either manually or automatically passed when calling child functions and using it and their `frame_offset` values are imported.
When using `jit_insn_call` on a nested function the frame pointer is passed automatically. In many languages there is a concept of closures (some call it delegate), essentially they are functions with a context pointer, very often they are nested functions plus a pointer to their parents frame (which of course are only valid as long as their parent function has not returned yet).
Previousely one was not able to create such a data type using libjit as there was no way of calling a nested function using it's function pointer. This is now possible using `jit_insn_get_frame_pointer` or `jit_insn_get_parent_frame_pointer_of` to retrieve the frame pointer of the current function or a ancestor respectively and then call the nested function using `jit_insn_call_nested_indirect`. If a child function has a custom way of retrieving it's parent frame pointer (e.g. through a local variable) it can do so and sets it using `jit_function_set_parent_frame` before importing values.

The following pseudo code is a small exmaple which shows what was previousely not possible:
```C
int foo(int x, int y, int z)
{
  int child1() { return y; }
  int child2() { return z; }

  closure f;
  if(x)
    f = child1;
  else
    f = child2;

  return f();
}
```

I've tested the code of this pull request on x86 (cross compiled), x86_64 and the interpreter.