### PR TITLE
Misc fixes & improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2019-10-01  Jakob Löw  <jakob@m4gnus.de>
+
+	* jit/jit-insn.c: Fix a segmentation fault bug when converting byte/short
+	values to larger ints.
+	* jit/jit-unwind.c: make sure the address of the next base pointer is
+	actually on the stack
+	* jit-rules-x86-64.ins: use lea, inc, dec in the jit instruction
+	add_relative, add and sub
+
 2019-08-10  Aleksey Demakov  <ademakov@gmail.com>
 
 	* tools/Makefile.am (gen_ops_SOURCES): reorder targtes wich seems

--- a/jit/jit-insn.c
+++ b/jit/jit-insn.c
@@ -4236,7 +4236,8 @@ apply_conversion(jit_function_t func, int oper, jit_value_t value,
 		       jit_type_t result_type)
 {
 	/* Set the "may_throw" flag if the conversion may throw an exception */
-	if(convert_intrinsics[oper - 1].descr.ptr_result_type)
+	if(oper < sizeof(convert_intrinsics) / sizeof(jit_convert_intrinsic_t)
+		&& convert_intrinsics[oper - 1].descr.ptr_result_type)
 	{
 		func->builder->may_throw = 1;
 	}

--- a/jit/jit-rules-x86-64.ins
+++ b/jit/jit-rules-x86-64.ins
@@ -925,11 +925,10 @@ JIT_OP_STORE_RELATIVE_STRUCT: ternary
 	}
 
 JIT_OP_ADD_RELATIVE:
-	[reg, imms32] -> {
-		if($2 != 0)
-		{
-			x86_64_add_reg_imm_size(inst, $1, $2, 8);
-		}
+	[reg, immzero] -> {
+	}
+	[=reg, reg, imms32] -> {
+		x86_64_lea_membase_size(inst, $1, $2, $3, 8);
 	}
 
 /*
@@ -1028,14 +1027,24 @@ JIT_OP_STORE_ELEMENT_FLOAT64: ternary
  */
 
 JIT_OP_IADD: commutative
-	[reg, imm] -> {
-		if($2 == 1)
+	[reg, immzero] -> {
+	}
+	[=reg, reg, imms32] -> {
+		if($1 != $2)
+		{
+			x86_64_lea_membase_size(inst, $1, $2, $3, 4);
+		}
+		else if($3 == 1)
 		{
 			x86_64_inc_reg_size(inst, $1, 4);
 		}
+		else if($3 == -1)
+		{
+			x86_64_dec_reg_size(inst, $1, 4);
+		}
 		else
 		{
-			x86_64_add_reg_imm_size(inst, $1, $2, 4);
+			x86_64_add_reg_imm_size(inst, $1, $3, 4);
 		}
 	}
 	[reg, local] -> {
@@ -1046,14 +1055,24 @@ JIT_OP_IADD: commutative
 	}
 
 JIT_OP_ISUB:
-	[reg, imm] -> {
-		if($2 == 1)
+	[reg, immzero] -> {
+	}
+	[=reg, reg, imms32] -> {
+		if($1 != $2)
+		{
+			x86_64_lea_membase_size(inst, $1, $2, -$3, 4);
+		}
+		else if($3 == 1)
 		{
 			x86_64_dec_reg_size(inst, $1, 4);
 		}
+		else if($3 == -1)
+		{
+			x86_64_inc_reg_size(inst, $1, 4);
+		}
 		else
 		{
-			x86_64_sub_reg_imm_size(inst, $1, $2, 4);
+			x86_64_sub_reg_imm_size(inst, $1, $3, 4);
 		}
 	}
 	[reg, local] -> {
@@ -1284,14 +1303,24 @@ JIT_OP_IREM_UN: more_space
  */
 
 JIT_OP_LADD: commutative
-	[reg, imms32] -> {
-		if($2 == 1)
+	[reg, immzero] -> {
+	}
+	[=reg, reg, imms32] -> {
+		if($1 != $2)
+		{
+			x86_64_lea_membase_size(inst, $1, $2, $3, 8);
+		}
+		else if($3 == 1)
 		{
 			x86_64_inc_reg_size(inst, $1, 8);
 		}
+		else if($3 == -1)
+		{
+			x86_64_dec_reg_size(inst, $1, 8);
+		}
 		else
 		{
-			x86_64_add_reg_imm_size(inst, $1, $2, 8);
+			x86_64_add_reg_imm_size(inst, $1, $3, 8);
 		}
 	}
 	[reg, local] -> {
@@ -1302,14 +1331,24 @@ JIT_OP_LADD: commutative
 	}
 
 JIT_OP_LSUB:
-	[reg, imms32] -> {
-		if($2 == 1)
+	[reg, immzero] -> {
+	}
+	[=reg, reg, imms32] -> {
+		if($1 != $2)
+		{
+			x86_64_lea_membase_size(inst, $1, $2, -$3, 8);
+		}
+		else if($3 == 1)
 		{
 			x86_64_dec_reg_size(inst, $1, 8);
 		}
+		else if($3 == -1)
+		{
+			x86_64_inc_reg_size(inst, $1, 8);
+		}
 		else
 		{
-			x86_64_sub_reg_imm_size(inst, $1, $2, 8);
+			x86_64_sub_reg_imm_size(inst, $1, $3, 8);
 		}
 	}
 	[reg, local] -> {

--- a/jit/jit-unwind.c
+++ b/jit/jit-unwind.c
@@ -111,6 +111,8 @@ jit_unwind_next(jit_unwind_context_t *unwind)
 int
 jit_unwind_next_pc(jit_unwind_context_t *unwind)
 {
+	void *next;
+
 	if(!unwind || !unwind->frame)
 	{
 		return 0;
@@ -119,10 +121,19 @@ jit_unwind_next_pc(jit_unwind_context_t *unwind)
 	unwind->cache = 0;
 
 #if defined(JIT_BACKEND_INTERP) || JIT_APPLY_BROKEN_FRAME_BUILTINS != 0
-	unwind->frame =  ((jit_backtrace_t) unwind->frame)->parent;
+	next = ((jit_backtrace_t) unwind->frame)->parent;
 #else
-	unwind->frame = jit_get_next_frame_address(unwind->frame);
+	next = jit_get_next_frame_address(unwind->frame);
 #endif
+
+	if(next <= unwind->frame)
+	{
+		unwind->frame = 0;
+	}
+	else
+	{
+		unwind->frame = next;
+	}
 	return (unwind->frame != 0);
 }
 


### PR DESCRIPTION
Hey,

this PR contains 3 commits not related to any bigger feature/improvements.

- 54e7090 adds a simple sanity check to the unwinder, to make sure the next frame pointer is still on the stack and not some invalid address read from the stack.
- e385fd1 fixes a possible segmentation fault where trying to convert byte/short values to larger ints
- f75ded9 are simple improvements to the x86-64 implementation of the add/sub/add_relative instructions.

I've also found some time to work on the register allocator (see [post-gsoc](https://github.com/M4GNV5/libjit/tree/post-gsoc)), fixing plenty of bugs. In case i dont find more i wil create a pull request for it later this month.