### PR TITLE
Optimize a jump-around-branch case

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-01-06  Tom Tromey  <tom@tromey.com>
+
+	* tests/unit/Makefile.am (jitlib, AM_CFLAGS, check_PROGRAMS)
+	(cfg_tests_SOURCES, cfg_tests_LDADD): New variables.
+	* tests/unit/unit-tests.h: New file.
+	* tests/unit/cfg-tests.c: New file.
+
 2019-12-27  Tom Tromey  <tom@tromey.com>
 
 	* jit/jit-block.c (_jit_invert_condition): New function.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-01-06  Tom Tromey  <tom@tromey.com>
+
+	* tests/unit/Makefile.am: New file.
+	* tests/Makefile.am (SUBDIRS): Add "unit".
+	* configure.ac: Add tests/unit/Makefile.
+
 2019-12-27  Tom Tromey  <tom@tromey.com>
 
 	* jit/jit-rules-x86-64.c (_jit_gen_load_value): Remove unused

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-12-27  Tom Tromey  <tom@tromey.com>
+
+	* jit/jit-block.c (_jit_invert_condition): New function.
+	(_jit_block_clean_cfg): Optimize branch-around-branch.
+
 2020-01-06  Tom Tromey  <tom@tromey.com>
 
 	* tests/unit/Makefile.am: New file.

--- a/configure.ac
+++ b/configure.ac
@@ -473,5 +473,6 @@ AC_CONFIG_FILES([
   tutorial/Makefile
   tests/Makefile
   tests/misc/Makefile
+  tests/unit/Makefile
   doc/Makefile])
 AC_OUTPUT

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = misc
+SUBDIRS = misc unit
 
 TESTS = coerce.pas \
 		loop.pas \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -1,1 +1,11 @@
 ## Unit tests.
+
+jitlib = $(top_builddir)/jit/libjit.la
+
+AM_CFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include
+
+check_PROGRAMS = cfg-tests
+TESTS = $(check_PROGRAMS)
+
+cfg_tests_SOURCES = cfg-tests.c
+cfg_tests_LDADD = $(jitlib)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -1,0 +1,1 @@
+## Unit tests.

--- a/tests/unit/cfg-tests.c
+++ b/tests/unit/cfg-tests.c
@@ -1,0 +1,106 @@
+/*
+ * cfg-tests.c - Simple CFG tests
+ *
+ * Copyright (C) 2020 Free Software Foundation
+ *
+ * This file is part of the libjit library.
+ *
+ * The libjit library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * The libjit library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the libjit library.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <jit/jit.h>
+#include "unit-tests.h"
+
+/* Make a block like
+
+   x = INCOMING
+   if INCOMING != 0 then goto .L0
+   goto .L1
+   .L0:
+   x = 23
+   .L1:
+   return x
+
+   Then, check that the optimized CFG removes the unnecessary block,
+   inverting the condition.  */
+
+static void test_block_removal(void)
+{
+	jit_init();
+	jit_context_t ctx = jit_context_create ();
+
+	jit_type_t params[1] = { jit_type_sys_int };
+	jit_type_t sig = jit_type_create_signature (jit_abi_cdecl,
+						    jit_type_sys_int,
+						    params, 1, 1);
+
+	jit_label_t l0 = jit_label_undefined;
+	jit_label_t l1 = jit_label_undefined;
+
+	jit_function_t func = jit_function_create (ctx, sig);
+	jit_value_t incoming = jit_value_get_param (func, 0);
+
+	jit_value_t x = jit_value_create (func, jit_type_int);
+	jit_insn_store (func, x, incoming);
+
+	jit_value_t zero = jit_value_create_nint_constant (func,
+							   jit_type_sys_int,
+							   0);
+	jit_value_t compare = jit_insn_ne (func, x, zero);
+	jit_block_t saved_block = jit_function_get_current (func);
+	jit_insn_branch_if (func, compare, &l1);
+
+	jit_insn_branch (func, &l0);
+
+	jit_insn_label (func, &l1);
+	jit_value_t twenty_three
+	  = jit_value_create_nint_constant (func, jit_type_sys_int, 23);
+	jit_insn_store (func, x, twenty_three);
+
+	jit_insn_label (func, &l0);
+	jit_insn_return (func, x);
+
+	/* Test that optimization removes the unnecessary block.  We
+	   do this by examining the instruction rather than the CFG,
+	   because there didn't seem to be a reliable way to do the
+	   latter.  */
+	unsigned max = jit_function_get_max_optimization_level ();
+	jit_function_set_optimization_level (func, max);
+	// jit_dump_function (stderr, func, "test_block_removal");
+	jit_function_compile (func);
+	jit_insn_iter_t iter;
+	jit_insn_iter_init_last (&iter, saved_block);
+	jit_insn_t insn = jit_insn_iter_previous (&iter);
+	CHECK (insn != NULL);
+	CHECK (jit_insn_get_opcode (insn) == JIT_OP_BR_IEQ);
+
+	/* Test that the result is still correct.  */
+	int result = -1;
+	int arg = 0;
+	void *args[] = { &arg };
+	CHECK (jit_function_apply (func, args, &result));
+	CHECK (result == 0);
+
+	arg = 72;
+	CHECK (jit_function_apply (func, args, &result));
+	CHECK (result == 23);
+}
+
+int main()
+{
+	test_block_removal ();
+
+	return 0;
+}

--- a/tests/unit/unit-tests.h
+++ b/tests/unit/unit-tests.h
@@ -1,0 +1,41 @@
+/*
+ * unit-tests.h - Defines for unit tests.
+ *
+ * Copyright (C) 2020 Free Software Foundation
+ *
+ * This file is part of the libjit library.
+ *
+ * The libjit library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * The libjit library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the libjit library.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _JIT_TESTS_UNIT_TESTS_H
+#define _JIT_TESTS_UNIT_TESTS_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Convenience.  */
+#include <jit/jit-dump.h>
+
+#define CHECK(val)							\
+	do {								\
+		if (!(val)) {						\
+			fprintf (stderr, "%s:%d: error: test failure\n", \
+				 __FILE__, __LINE__);			\
+			exit (1);					\
+		}							\
+	} while (0)
+
+#endif /* _JIT_TESTS_UNIT_TESTS_H */


### PR DESCRIPTION
In my Emacs JIT I noticed that sometimes libjit would emit a
conditional jump to branch around an unconditional jump, like:

    7ffff7fe5160:	0f 85 05 00 00 00    	jne    0x7ffff7fe516b
    7ffff7fe5166:	e9 0e 00 00 00       	jmpq   0x7ffff7fe5179
    7ffff7fe516b:	41 bf 17 00 00 00    	mov    $0x17,%r15d

While this can be worked around by constructing the IL a bit
differently, I was curious about the difficulty of fixing this in the
libjit optimizer.

This patch notices the specific case where a conditional branch simply
jumps around an unconditional branch.  In this case, the condition is
inverted and the extra jump is eliminated.