### PR TITLE
Check for functions that are documented but not declared

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2020-01-09  Tom Tromey  <tom@tromey.com>
+
+	* include/jit/jit-function.h (jit_optimize, jit_compile)
+	(jit_compile_entry): Declare.
+	* include/jit/jit-intrinsic.h (jit_int_div_ovf, jit_int_rem_ovf)
+	(jit_uint_div_ovf, jit_uint_rem_ovf, jit_long_div_ovf)
+	(jit_long_rem_ovf, jit_ulong_div_ovf, jit_ulong_rem_ovf):
+	Declare.
+	* tests/unit/Makefile.am (check-local): New target.
+	* tests/unit/make-includes-test: New file.
+
 2020-01-06  Tom Tromey  <tom@tromey.com>
 
 	* tests/unit/Makefile.am (jitlib, AM_CFLAGS, check_PROGRAMS)

--- a/include/jit/jit-function.h
+++ b/include/jit/jit-function.h
@@ -82,6 +82,9 @@ unsigned int jit_function_get_optimization_level
 unsigned int jit_function_get_max_optimization_level(void) JIT_NOTHROW;
 jit_label_t jit_function_reserve_label(jit_function_t func) JIT_NOTHROW;
 int jit_function_labels_equal(jit_function_t func, jit_label_t label, jit_label_t label2);
+int jit_optimize(jit_function_t func);
+int jit_compile(jit_function_t func);
+int jit_compile_entry(jit_function_t func, void **entry_point);
 
 #ifdef	__cplusplus
 };

--- a/include/jit/jit-intrinsic.h
+++ b/include/jit/jit-intrinsic.h
@@ -43,6 +43,10 @@ jit_int jit_int_sub_ovf
 	(jit_int *result, jit_int value1, jit_int value2) JIT_NOTHROW;
 jit_int jit_int_mul_ovf
 	(jit_int *result, jit_int value1, jit_int value2) JIT_NOTHROW;
+jit_int jit_int_div_ovf
+	(jit_int *result, jit_int value1, jit_int value2) JIT_NOTHROW;
+jit_int jit_int_rem_ovf
+	(jit_int *result, jit_int value1, jit_int value2) JIT_NOTHROW;
 jit_int jit_int_neg(jit_int value1) JIT_NOTHROW;
 jit_int jit_int_and(jit_int value1, jit_int value2) JIT_NOTHROW;
 jit_int jit_int_or(jit_int value1, jit_int value2) JIT_NOTHROW;
@@ -78,6 +82,10 @@ jit_int jit_uint_sub_ovf
 	(jit_uint *result, jit_uint value1, jit_uint value2) JIT_NOTHROW;
 jit_int jit_uint_mul_ovf
 	(jit_uint *result, jit_uint value1, jit_uint value2) JIT_NOTHROW;
+jit_int jit_uint_div_ovf
+	(jit_uint *result, jit_uint value1, jit_uint value2) JIT_NOTHROW;
+jit_int jit_uint_rem_ovf
+	(jit_uint *result, jit_uint value1, jit_uint value2) JIT_NOTHROW;
 jit_uint jit_uint_neg(jit_uint value1) JIT_NOTHROW;
 jit_uint jit_uint_and(jit_uint value1, jit_uint value2) JIT_NOTHROW;
 jit_uint jit_uint_or(jit_uint value1, jit_uint value2) JIT_NOTHROW;
@@ -110,6 +118,10 @@ jit_int jit_long_add_ovf
 jit_int jit_long_sub_ovf
 	(jit_long *result, jit_long value1, jit_long value2) JIT_NOTHROW;
 jit_int jit_long_mul_ovf
+	(jit_long *result, jit_long value1, jit_long value2) JIT_NOTHROW;
+jit_int jit_long_div_ovf
+	(jit_long *result, jit_long value1, jit_long value2) JIT_NOTHROW;
+jit_int jit_long_rem_ovf
 	(jit_long *result, jit_long value1, jit_long value2) JIT_NOTHROW;
 jit_long jit_long_neg(jit_long value1) JIT_NOTHROW;
 jit_long jit_long_and(jit_long value1, jit_long value2) JIT_NOTHROW;
@@ -145,6 +157,10 @@ jit_int jit_ulong_add_ovf
 jit_int jit_ulong_sub_ovf
 	(jit_ulong *result, jit_ulong value1, jit_ulong value2) JIT_NOTHROW;
 jit_int jit_ulong_mul_ovf
+	(jit_ulong *result, jit_ulong value1, jit_ulong value2) JIT_NOTHROW;
+jit_int jit_ulong_div_ovf
+	(jit_ulong *result, jit_ulong value1, jit_ulong value2) JIT_NOTHROW;
+jit_int jit_ulong_rem_ovf
 	(jit_ulong *result, jit_ulong value1, jit_ulong value2) JIT_NOTHROW;
 jit_ulong jit_ulong_neg(jit_ulong value1) JIT_NOTHROW;
 jit_ulong jit_ulong_and(jit_ulong value1, jit_ulong value2) JIT_NOTHROW;

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -9,3 +9,8 @@ TESTS = $(check_PROGRAMS)
 
 cfg_tests_SOURCES = cfg-tests.c
 cfg_tests_LDADD = $(jitlib)
+
+# It's enough for this program to compile.
+check-local:
+	$(srcdir)/make-includes-test $(top_srcdir)/jit test-includes.c
+	$(CC) $(AM_CFLAGS) -c test-includes.c

--- a/tests/unit/make-includes-test
+++ b/tests/unit/make-includes-test
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+srcdir="$1"
+FILE="$2"
+
+echo "#include <jit/jit.h>" > $FILE
+echo "#include <jit/jit-dump.h>" >> $FILE
+echo "#include <jit/jit-intrinsic.h>" >> $FILE
+
+for file in $srcdir/*.c; do
+    # We filter out _jit functions because it isn't clear that these
+    # should be exported.  We also filter out a few documented things
+    # that aren't really functions.
+    grep '@deftypefun' $file | \
+	sed -e 's/^.*@deftypefun/@deftypefun/' \
+	    -e 's/^[^ ]* \({[^}]*}\|[^ {]\)* \([^ ]*\) .*$/\2/' | \
+	grep -v '^_jit' | \
+	grep -v jit_get_frame_address | \
+	grep -v jit_get_current_frame | \
+	grep -v jit_get_next_frame_address | \
+	grep -v jit_get_return_address | \
+	grep -v jit_get_current_return | \
+	grep -v jit_new | \
+	grep -v jit_cnew
+done | \
+    nl -s " = " | \
+    sed -e "s/^ */void *x_$name/" -e 's/$/;/' >> $FILE
+
+# Just compiling is enough, so we make the test program always
+# succeed.
+echo "int main() { return 0; }" >> $FILE


### PR DESCRIPTION
This adds some code to "make check" to look for functions that are
documented but not declared in a public header.  This found a few such
missing functions; this is also fixed in this patch.

Fixes #20