### PR TITLE
add inversions of OP_BR_IFALSE and OP_BR_ITRUE to _jit_invert_condition

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-05-10  Jakob Löw  <jakob@m4gnus.de>
+
+	* jit/jit-block.c: add missing inversions of OP_BR_IFALSE and
+	OP_BR_ITRUE to _jit_invert_condition.
+
 2020-04-17  Aleksey Demakov  <ademakov@gmail.com>
 
 	* include/jit/jit.h: Include jit-dump.h and jit-memory.h headers.

--- a/jit/jit-block.c
+++ b/jit/jit-block.c
@@ -768,6 +768,8 @@ _jit_invert_condition (int opcode)
 {
 	switch(opcode)
 	{
+	case JIT_OP_BR_IFALSE:	opcode = JIT_OP_BR_ITRUE;   break;
+	case JIT_OP_BR_ITRUE:	opcode = JIT_OP_BR_IFALSE;   break;
 	case JIT_OP_BR_IEQ:	opcode = JIT_OP_BR_INE;      break;
 	case JIT_OP_BR_INE:	opcode = JIT_OP_BR_IEQ;      break;
 	case JIT_OP_BR_ILT:	opcode = JIT_OP_BR_IGE;      break;


### PR DESCRIPTION
I stumbled upon these two missing causing programs to break when the IR looks like this:

```S
if ifalse(i1) then goto .L0
goto .L1
.L0:
```